### PR TITLE
Fix map zoom for clustered markers

### DIFF
--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -22,6 +22,7 @@ describe("MapComponent", () => {
   beforeEach(async () => {
     mockMarkerService = jasmine.createSpyObj("MarkerService", [
       "makeBreweryMarkers",
+      "getMarkerByBreweryId",
     ]);
     mockDataService = jasmine.createSpyObj("DataService", ["getBeers"]);
     mockDataService.getBeers.and.returnValue(
@@ -68,6 +69,49 @@ describe("MapComponent", () => {
     flush();
 
     expect(mockMarkerService.makeBreweryMarkers).toHaveBeenCalled();
+
+    fixture.destroy();
+    document.body.removeChild(mapDiv);
+  }));
+
+  it("should use zoomToShowLayer for deep links when marker exists", fakeAsync(() => {
+    // We need a div with the mapId in the DOM for Leaflet to initialize
+    const mapDiv = document.createElement("div");
+    mapDiv.id = "myMap";
+    document.body.appendChild(mapDiv);
+
+    const mockMarker: any = {
+      getElement: jasmine.createSpy("getElement").and.returnValue(
+        document.createElement("div"),
+      ),
+      breweryId: "brewery-1",
+      checkInsData: {
+        name: "Test Brewery",
+        city: "Test City",
+        state: "TS",
+        logo: "logo.png",
+        checkIns: [],
+      },
+    };
+
+    mockMarkerService.getMarkerByBreweryId.and.returnValue(mockMarker);
+    mockMarkerService.markers = {
+      zoomToShowLayer: jasmine
+        .createSpy("zoomToShowLayer")
+        .and.callFake((m: any, cb: any) => cb()),
+    };
+
+    // Trigger AfterViewInit
+    fixture.detectChanges();
+    tick();
+
+    // Directly call the private handleDeepLink via any to test the logic
+    (component as any).handleDeepLink(10, 20, "brewery-1");
+
+    expect(mockMarkerService.markers.zoomToShowLayer).toHaveBeenCalledWith(
+      mockMarker,
+      jasmine.any(Function),
+    );
 
     fixture.destroy();
     document.body.removeChild(mapDiv);

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -282,14 +282,20 @@ export class MapComponent implements OnInit, AfterViewInit, OnDestroy {
   private handleDeepLink(lat: number, lng: number, breweryId: string) {
     if (!this.map) return;
 
-    this.map.setView([lat, lng], 16, { animate: true, duration: 1.5 });
-    this.openBreweryOverlay(breweryId);
-
     const marker = this.markerService.getMarkerByBreweryId(breweryId);
-    if (marker && marker.getElement()) {
-      const el = marker.getElement();
-      el?.classList.add("marker-pulse");
-      setTimeout(() => el?.classList.remove("marker-pulse"), 3000);
+    if (marker) {
+      this.markerService.markers.zoomToShowLayer(marker, () => {
+        this.openBreweryOverlay(breweryId);
+        const el = marker.getElement();
+        if (el) {
+          el.classList.add("marker-pulse");
+          setTimeout(() => el.classList.remove("marker-pulse"), 3000);
+        }
+      });
+    } else {
+      // Fallback if marker not found
+      this.map.setView([lat, lng], 16, { animate: true, duration: 1.5 });
+      this.openBreweryOverlay(breweryId);
     }
   }
 


### PR DESCRIPTION
This change fixes an issue where clicking "Go to Map" from the beer history page wouldn't zoom correctly if the brewery's marker was part of a cluster. I've integrated Leaflet.markercluster's `zoomToShowLayer` method, which automatically handles expanding the cluster and zooming to the specific marker before opening the info overlay. I also added a unit test to ensure this logic is preserved.

Fixes #136

---
*PR created automatically by Jules for task [13126812261792807404](https://jules.google.com/task/13126812261792807404) started by @cfrome77*