### PR TITLE
Fix Stats page alignment inconsistency

### DIFF
--- a/src/app/components/stats/stats.component.css
+++ b/src/app/components/stats/stats.component.css
@@ -86,23 +86,25 @@
 .beer-styles-breakdown,
 .top-beers,
 .card-list {
-  grid-column: span 1;
+  grid-column: 1 / -1;
   align-items: stretch;
   text-align: left;
-  display: block;
+  display: flex;
+  flex-direction: column;
 }
 
 @media (max-width: 768px) {
   .beer-styles-breakdown,
   .top-beers,
   .card-list {
-    grid-column: span 1;
+    grid-column: 1 / -1;
   }
 }
 
 .card h3 {
   margin-top: 0;
   margin-bottom: 1.5rem;
+  padding: 0 14px;
   font-size: 1.2rem;
   font-weight: 700;
   color: var(--header-text);


### PR DESCRIPTION
The Stats page had an inconsistent layout where list-based cards (like "Top Beers" and "Beer Styles Breakdown") were mixing unevenly with small metric cards in the grid. This caused misalignment and empty spaces.

I updated the CSS to make these list-based sections span the full width of the grid, ensuring they are always stacked below the metrics for a cleaner, more balanced look. I also aligned the section titles with the list content by adding matching horizontal padding and standardized the flexbox behavior across all card types.

Verified the fix with Playwright E2E layout tests and confirmed it looks correct on both desktop and mobile views.

Fixes #130

---
*PR created automatically by Jules for task [10940298106684501577](https://jules.google.com/task/10940298106684501577) started by @cfrome77*