### PR TITLE
Optimize Lighthouse performance and SEO score

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -192,6 +192,8 @@
       src="assets/images/poweredbyuntappd.png"
       alt="Powered by Untappd"
       class="untappd-logo"
+      width="200"
+      height="75"
     />
   </div>
   <div class="fab-container">

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -1,6 +1,13 @@
 <div class="home-container">
   <div class="hero">
-    <img src="assets/images/LiquidStatsLogo.png" alt="Logo" class="logo-hero" />
+    <img
+      src="assets/images/LiquidStatsLogo.png"
+      alt="Logo"
+      class="logo-hero"
+      width="420"
+      height="234"
+      fetchpriority="high"
+    />
     <div class="hero-content-wrapper">
       <p class="hero-subtitle">Track every pour you enjoy.</p>
       <div class="hero-buttons">
@@ -90,6 +97,7 @@
             "
             [alt]="c.beer?.beer_name"
             (error)="handleImageError($event)"
+            loading="lazy"
           />
           <mat-card-content>
             <h4>{{ c.beer?.beer_name }}</h4>

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -3,15 +3,25 @@ import { HomeComponent } from "./home.component";
 import { RouterTestingModule } from "@angular/router/testing";
 import { ActivatedRoute } from "@angular/router";
 import { of } from "rxjs";
+import { DataService } from "../../core/services/data.service";
 
 describe("HomeComponent", () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
+  let mockDataService: any;
 
   beforeEach(async () => {
+    mockDataService = {
+      getBeers: () => of({ beers: [] }),
+      getCheckins: () => of({ response: { checkins: { items: [] } } }),
+    };
+
     await TestBed.configureTestingModule({
       imports: [HomeComponent, RouterTestingModule],
-      providers: [{ provide: ActivatedRoute, useValue: { params: of({}) } }],
+      providers: [
+        { provide: ActivatedRoute, useValue: { params: of({}) } },
+        { provide: DataService, useValue: mockDataService },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(HomeComponent);

--- a/src/app/components/map/map.component.spec.ts
+++ b/src/app/components/map/map.component.spec.ts
@@ -84,6 +84,9 @@ describe("MapComponent", () => {
       getElement: jasmine
         .createSpy("getElement")
         .and.returnValue(document.createElement("div")),
+      getLatLng: jasmine
+        .createSpy("getLatLng")
+        .and.returnValue({ lat: 10, lng: 20 }),
       breweryId: "brewery-1",
       checkInsData: {
         name: "Test Brewery",

--- a/src/index.html
+++ b/src/index.html
@@ -5,18 +5,23 @@
     <title>Liquid Stats</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content="Liquid Stats - Track every pour you enjoy. View your beer history, checkins, and statistics." />
+    <meta name="theme-color" content="#c2185b" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+    <link rel="manifest" href="manifest.webmanifest" />
+
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://www.googletagmanager.com" crossorigin />
+    <link rel="preconnect" href="https://www.google-analytics.com" crossorigin />
+    <link rel="preconnect" href="https://assets.untappd.com" crossorigin />
+    <link rel="preconnect" href="https://images.untp.beer" crossorigin />
+
     <link
-      href="https://fonts.googleapis.com/css?family=Roboto:300,400,500&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Montserrat:wght@400;700&family=Nunito:wght@400;700&family=Roboto:wght@300;400;500&display=swap"
       rel="stylesheet"
     />
     <link
       href="https://fonts.googleapis.com/icon?family=Material+Icons&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="preconnect" href="https://fonts.gstatic.com" />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@300;400;500&display=swap"
       rel="stylesheet"
     />
   </head>

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,5 +1,4 @@
 /* Importing fonts and styles */
-@import url("https://fonts.googleapis.com/css?family=Nunito|Montserrat:400,700");
 
 :root {
   /* Layout & Spacing */


### PR DESCRIPTION
I have implemented several performance and SEO optimizations to improve the Lighthouse score from 48 to a much higher value. Key changes include:
- **LCP Optimization**: The hero logo now has explicit `width`/`height` and `fetchpriority="high"`.
- **Render-Blocking Assets**: Moved font loading from CSS `@import` to HTML `<link>` with `&display=swap` and added `preconnect` hints for Google and Untappd domains.
- **Lazy Loading**: Applied `loading="lazy"` to the recent check-ins carousel images.
- **PWA & SEO**: Fixed the missing web manifest link and added meta description/theme-color tags.
- **Test Stability**: Fixed a pre-existing failure in `MapComponent` unit tests and properly mocked `DataService` in `HomeComponent` tests.

These changes were verified visually with Playwright and all unit tests passed.

---
*PR created automatically by Jules for task [7381247576783702545](https://jules.google.com/task/7381247576783702545) started by @cfrome77*