### PR TITLE
Fix Accessibility Contrast Ratios for Icon Elements

### DIFF
--- a/src/app/components/home/home.component.css
+++ b/src/app/components/home/home.component.css
@@ -126,7 +126,6 @@
   line-height: 44px;
   margin-bottom: 16px;
   color: var(--accent-blue);
-  opacity: 0.8;
 }
 
 .stat-number {
@@ -184,7 +183,6 @@
 }
 
 .icon-default {
-  opacity: 0.8;
   visibility: visible;
   color: var(--accent-blue);
 }
@@ -303,7 +301,6 @@
   text-transform: uppercase;
   font-weight: 700;
   color: var(--accent-blue);
-  opacity: 0.8;
   white-space: nowrap; /* Desktop: 1 line */
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/styles.css
+++ b/src/styles.css
@@ -34,6 +34,8 @@
   --bg-color: #121212;
   --text-color: #e0e0e0;
   --card-bg: #1e1e1e;
+  --accent-blue: #42a5f5;
+  --accent-blue-rgb: 66, 165, 245;
   --navbar-bg: #212121;
   --navbar-text: #ffffff;
   --header-text: #ffffff;


### PR DESCRIPTION
Improve icon and text contrast on the home page to meet WCAG AA accessibility standards.
Specifically, adjusted the dark theme accent blue color and removed opacity constraints from key UI elements to ensure a contrast ratio of at least 4.5:1.
Verified the changes with Playwright screenshots in both light and dark themes.

Fixes #168

---
*PR created automatically by Jules for task [6260449253333005839](https://jules.google.com/task/6260449253333005839) started by @cfrome77*