### PR TITLE
Delay GTM initialization to reduce TBT

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -65,10 +65,17 @@ export class AppComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    // Load and initialize GA4 after a delay to improve initial page load performance
-    setTimeout(() => {
-      this.ga4Service.loadAndInitialize();
-    }, 2000);
+    // Load and initialize GA4 when the browser is idle to improve initial page load performance
+    if ("requestIdleCallback" in window) {
+      (window as any).requestIdleCallback(() => {
+        this.ga4Service.loadAndInitialize();
+      });
+    } else {
+      // Fallback for browsers that don't support requestIdleCallback
+      setTimeout(() => {
+        this.ga4Service.loadAndInitialize();
+      }, 2000);
+    }
 
     // Subscribe to only NavigationEnd events for GA tracking
     this.router.events

--- a/src/app/core/services/ga4-tracking.service.ts
+++ b/src/app/core/services/ga4-tracking.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@angular/core";
+import { Injectable, NgZone } from "@angular/core";
 import { environment } from "src/environments/environment";
 
 // 🚨 Declare gtag globally so TypeScript knows it exists
@@ -11,62 +11,68 @@ export class Ga4TrackingService {
   private readonly MEASUREMENT_ID = environment.GA4_MEASUREMENT_ID;
   private isScriptLoaded = false;
 
+  constructor(private ngZone: NgZone) {}
+
   /**
    * 1. Dynamically loads the gtag script and initializes GA4.
    */
   public loadAndInitialize(): void {
-    if (this.isScriptLoaded || !this.MEASUREMENT_ID) {
-      console.warn("GA4 script already loaded or Measurement ID missing.");
-      return;
-    }
+    this.ngZone.runOutsideAngular(() => {
+      if (this.isScriptLoaded || !this.MEASUREMENT_ID) {
+        console.warn("GA4 script already loaded or Measurement ID missing.");
+        return;
+      }
 
-    // A. Inject the script tag into the <head>
-    const script = document.createElement("script");
-    script.async = true;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${this.MEASUREMENT_ID}`;
-    document.head.appendChild(script);
+      // A. Inject the script tag into the <head>
+      const script = document.createElement("script");
+      script.async = true;
+      script.src = `https://www.googletagmanager.com/gtag/js?id=${this.MEASUREMENT_ID}`;
+      document.head.appendChild(script);
 
-    // B. Initialize the dataLayer and the gtag function
-    // This replicates the standard inline script block
-    (window as any).dataLayer = (window as any).dataLayer || [];
-    (window as any).gtag = function () {
-      (window as any).dataLayer.push(arguments);
-    };
-    (window as any).gtag("js", new Date());
+      // B. Initialize the dataLayer and the gtag function
+      // This replicates the standard inline script block
+      (window as any).dataLayer = (window as any).dataLayer || [];
+      (window as any).gtag = function () {
+        (window as any).dataLayer.push(arguments);
+      };
+      (window as any).gtag("js", new Date());
 
-    // C. Fire the initial configuration command
-    (window as any).gtag("config", this.MEASUREMENT_ID, {
-      // Disabling auto-page-view here prevents the script from firing a
-      // page_view *immediately* upon loading. We'll fire it manually next.
-      send_page_view: false,
+      // C. Fire the initial configuration command
+      (window as any).gtag("config", this.MEASUREMENT_ID, {
+        // Disabling auto-page-view here prevents the script from firing a
+        // page_view *immediately* upon loading. We'll fire it manually next.
+        send_page_view: false,
+      });
+
+      this.isScriptLoaded = true;
+      console.log(
+        `✅ GA4 script loaded and initialized with ID: ${this.MEASUREMENT_ID}`,
+      );
     });
-
-    this.isScriptLoaded = true;
-    console.log(
-      `✅ GA4 script loaded and initialized with ID: ${this.MEASUREMENT_ID}`,
-    );
   }
 
   /**
    * 2. Sends a manual page_view event to GA4 for all navigations.
    */
   public trackPageView(path: string, title: string): void {
-    if (typeof gtag !== "undefined" && this.MEASUREMENT_ID) {
-      // 1. Send the config to update the context (page_path/title)
-      gtag("config", this.MEASUREMENT_ID, {
-        page_path: path,
-        page_title: title,
-      });
+    this.ngZone.runOutsideAngular(() => {
+      if (typeof gtag !== "undefined" && this.MEASUREMENT_ID) {
+        // 1. Send the config to update the context (page_path/title)
+        gtag("config", this.MEASUREMENT_ID, {
+          page_path: path,
+          page_title: title,
+        });
 
-      // 2. Explicitly send the 'page_view' event
-      gtag("event", "page_view", {
-        page_location: window.location.origin + path,
-        page_title: title,
-      });
+        // 2. Explicitly send the 'page_view' event
+        gtag("event", "page_view", {
+          page_location: window.location.origin + path,
+          page_title: title,
+        });
 
-      console.log(`GA4 Page View Tracked: ${path}`);
-    } else {
-      console.warn("GA4 gtag not ready. Page view not tracked.");
-    }
+        console.log(`GA4 Page View Tracked: ${path}`);
+      } else {
+        console.warn("GA4 gtag not ready. Page view not tracked.");
+      }
+    });
   }
 }


### PR DESCRIPTION
This PR optimizes the initialization and execution of Google Tag Manager (GTM) / GA4 to improve application performance, specifically targeting Total Blocking Time (TBT).

Key changes:
1. **Deferred Initialization**: In `AppComponent`, the `loadAndInitialize` call is now wrapped in a `requestIdleCallback` (or a 2-second `setTimeout` fallback). This ensures that the analytics script is loaded only when the browser is idle, avoiding contention with critical hydration tasks.
2. **Zone-less Execution**: The `Ga4TrackingService` now uses `NgZone.runOutsideAngular` for both the initial script injection/configuration and the subsequent `trackPageView` events. This prevents third-party analytics activity from triggering Angular's change detection, further reducing CPU overhead on the main thread.

These optimizations directly address Lighthouse findings where `gtag.js` was identified as a major contributor to TBT.

Fixes #174

---
*PR created automatically by Jules for task [10420198178848243296](https://jules.google.com/task/10420198178848243296) started by @cfrome77*