### PR TITLE
Fix hero logo aspect ratio distortion

### DIFF
--- a/src/app/components/home/home.component.css
+++ b/src/app/components/home/home.component.css
@@ -49,6 +49,7 @@
 .logo-hero {
   max-width: 420px;
   width: 90%;
+  height: auto;
   filter: var(--logo-filter);
 }
 

--- a/src/app/components/home/home.component.html
+++ b/src/app/components/home/home.component.html
@@ -4,8 +4,8 @@
       ngSrc="assets/images/LiquidStatsLogo.webp"
       alt="Logo"
       class="logo-hero"
-      width="420"
-      height="234"
+      width="306"
+      height="171"
       priority
     />
     <div class="hero-content-wrapper">


### PR DESCRIPTION
This change resolves the aspect ratio distortion of the hero logo on the home page. The image was previously being squished because its width was set to 90% but its height was not allowed to scale proportionally. By setting `height: auto` in the CSS and providing the correct `width` and `height` hints (306x171, matching the natural 1280x714 ratio) to the `NgOptimizedImage` directive, the browser can now correctly calculate the aspect ratio, preventing re-paints and improving Lighthouse scores.

Fixes #179

---
*PR created automatically by Jules for task [7330743185322915141](https://jules.google.com/task/7330743185322915141) started by @cfrome77*