### PR TITLE
Unify Stats Logic and Fix Badge Layout/Data

### DIFF
--- a/src/app/components/badges/badges.component.ts
+++ b/src/app/components/badges/badges.component.ts
@@ -8,6 +8,7 @@ import { PaginationComponent } from "../../shared/components/pagination/paginati
 import { CardComponent } from "../../shared/components/card/card.component";
 import { BaseCardData } from "../../shared/components/card/card-data.interface";
 import { DomSanitizer } from "@angular/platform-browser";
+import { DateUtils } from "../../core/utils/date-utils";
 
 @Component({
   selector: "app-badges",
@@ -61,15 +62,7 @@ export class BadgesComponent implements OnInit {
   }
 
   transformBadgeData(badge: Badge): BaseCardData {
-    const dateObj = new Date(badge.earned_at);
-    const formattedDate = dateObj.toLocaleString("en-US", {
-      month: "short",
-      day: "numeric",
-      year: "numeric",
-      hour: "numeric",
-      minute: "2-digit",
-      hour12: true,
-    });
+    const formattedDate = DateUtils.formatTimestamp(badge.earned_at);
 
     return {
       title: badge.badge_name,

--- a/src/app/components/badges/badges.component.ts
+++ b/src/app/components/badges/badges.component.ts
@@ -8,7 +8,7 @@ import { PaginationComponent } from "../../shared/components/pagination/paginati
 import { CardComponent } from "../../shared/components/card/card.component";
 import { BaseCardData } from "../../shared/components/card/card-data.interface";
 import { DomSanitizer } from "@angular/platform-browser";
-import { DateUtils } from "../../core/utils/date-utils";
+import { DateUtils } from "src/app/core/utils/date-utils";
 
 @Component({
   selector: "app-badges",

--- a/src/app/components/checkins/checkins.component.ts
+++ b/src/app/components/checkins/checkins.component.ts
@@ -191,10 +191,11 @@ export class CheckinsComponent implements OnInit {
             md: b.badge_image,
             lg: b.badge_image,
           },
-          badge_description: "",
+          badge_description: "Badge earned during check-in.",
           badge_hint: "",
           media: { badge_image_sm: b.badge_image },
-          earned_at: "",
+          earned_at: checkin.created_at,
+          created_at: checkin.created_at,
           user_badge_id: 0,
         })) ?? [],
       socialLinks: {

--- a/src/app/components/checkins/checkins.component.ts
+++ b/src/app/components/checkins/checkins.component.ts
@@ -191,7 +191,8 @@ export class CheckinsComponent implements OnInit {
             md: b.badge_image,
             lg: b.badge_image,
           },
-          badge_description: "Badge earned during check-in.",
+          badge_description:
+            (b as any).badge_description || "Badge earned during check-in.",
           badge_hint: "",
           media: { badge_image_sm: b.badge_image },
           earned_at: checkin.created_at,

--- a/src/app/components/home/home.component.spec.ts
+++ b/src/app/components/home/home.component.spec.ts
@@ -4,17 +4,43 @@ import { RouterTestingModule } from "@angular/router/testing";
 import { ActivatedRoute } from "@angular/router";
 import { of } from "rxjs";
 import { DataService } from "../../core/services/data.service";
+import { BeerStoreService } from "../../core/services/beer-store.service";
 
 describe("HomeComponent", () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
   let mockDataService: Partial<DataService>;
+  let mockBeerStoreService: Partial<BeerStoreService>;
 
   beforeEach(async () => {
     mockDataService = {
       getBeers: () => of([]),
+      getBeersAll: () => of([]),
       getStats: () => of({}),
       getCheckins: () => of({ response: { checkins: { items: [] } } }),
+    };
+
+    mockBeerStoreService = {
+      load: () => {},
+      beers$: of([]),
+      stats$: of({
+        totalUniqueBeers: 0,
+        totalCheckins: 0,
+        newBeersCount: 0,
+        newBeerRatio: 0,
+        averageRating: 0,
+        totalUniqueBreweries: 0,
+        beerStylesCount: {},
+        topBeers: [],
+        topCountries: {},
+        topStates: {},
+        recentActivityByDate: [],
+        checkinsByHour: [],
+        checkinsByDay: [],
+        checkinsByDayOfWeek: [],
+        checkinsByMonth: [],
+        averageRatingsOverTime: [],
+      } as any),
     };
 
     await TestBed.configureTestingModule({
@@ -22,6 +48,7 @@ describe("HomeComponent", () => {
       providers: [
         { provide: ActivatedRoute, useValue: { params: of({}) } },
         { provide: DataService, useValue: mockDataService },
+        { provide: BeerStoreService, useValue: mockBeerStoreService },
       ],
     }).compileComponents();
 

--- a/src/app/components/home/home.component.ts
+++ b/src/app/components/home/home.component.ts
@@ -46,22 +46,16 @@ export class HomeComponent implements OnInit {
 
     this.beerStore.beers$.subscribe((beers) => {
       if (!beers) return;
-
       this.allCheckins = beers;
+    });
 
-      this.totalCheckins = beers.reduce((sum, b) => sum + (b.count ?? 1), 0);
+    this.beerStore.stats$.subscribe((stats) => {
+      if (!stats) return;
 
-      const ratings = beers.map((b) => b.rating_score);
-      this.averageRating =
-        ratings.reduce((a, b) => a + b, 0) / ratings.length || 0;
-
-      this.countriesTried = new Set(
-        beers.map((b) => b.brewery.country_name),
-      ).size;
-
-      this.breweriesVisited = new Set(
-        beers.map((b) => b.brewery.brewery_name),
-      ).size;
+      this.totalCheckins = stats.totalCheckins;
+      this.averageRating = stats.averageRating;
+      this.countriesTried = Object.keys(stats.topCountries).length;
+      this.breweriesVisited = stats.totalUniqueBreweries;
     });
   }
 

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -32,7 +32,7 @@ import { DataService } from "src/app/core/services/data.service";
 import * as L from "leaflet";
 import "leaflet.markercluster";
 import { BeerCheckin } from "src/app/core/models/beer.model";
-import { DateUtils } from "../../core/utils/date-utils";
+import { DateUtils } from "src/app/core/utils/date-utils";
 
 @Component({
   selector: "app-map",

--- a/src/app/components/map/map.component.ts
+++ b/src/app/components/map/map.component.ts
@@ -32,6 +32,7 @@ import { DataService } from "src/app/core/services/data.service";
 import * as L from "leaflet";
 import "leaflet.markercluster";
 import { BeerCheckin } from "src/app/core/models/beer.model";
+import { DateUtils } from "../../core/utils/date-utils";
 
 @Component({
   selector: "app-map",
@@ -290,7 +291,7 @@ export class MapComponent
         beerStyle: b.beer.beer_style ?? "Unknown",
         rating: b.rating_score ?? 0,
         checkInDate: b.recent_created_at
-          ? new Date(b.recent_created_at).toLocaleString()
+          ? DateUtils.formatTimestamp(b.recent_created_at)
           : "Unknown Date",
         checkInId: b.recent_checkin_id ?? 0,
       }));

--- a/src/app/components/stats/stats.component.spec.ts
+++ b/src/app/components/stats/stats.component.spec.ts
@@ -15,7 +15,6 @@ describe("StatsComponent", () => {
 
   beforeEach(async () => {
     mockStatsService = {
-      loadBeerData: () => of([]),
       computeStats: () => ({
         totalUniqueBeers: 0,
         totalCheckins: 0,

--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -18,7 +18,7 @@ import {
 } from "@angular/material/core";
 import { MatInputModule } from "@angular/material/input";
 import { MatIconModule } from "@angular/material/icon";
-import { MatDialog } from "@angular/material/dialog";
+import { MatDialog, MatDialogModule } from "@angular/material/dialog";
 import {
   BaseChartDirective,
   provideCharts,
@@ -52,6 +52,7 @@ import { BeerStoreService } from "src/app/core/services/beer-store.service";
     MatNativeDateModule,
     MatInputModule,
     MatIconModule,
+    MatDialogModule,
     BaseChartDirective,
   ],
   providers: [

--- a/src/app/components/stats/stats.component.ts
+++ b/src/app/components/stats/stats.component.ts
@@ -37,6 +37,7 @@ import {
 import { DateUtils } from "../../core/utils/date-utils";
 import { ThemeService } from "src/app/core/services/theme.service";
 import { BeerStoreService } from "src/app/core/services/beer-store.service";
+import { environment } from "src/environments/environment";
 
 @Component({
   selector: "app-stats",
@@ -369,6 +370,10 @@ export class StatsComponent implements OnInit, OnDestroy {
         beerABV: b.beer.beer_abv,
         rating: b.rating_score,
         checkInDate: b.recent_created_at,
+        checkinUrl:
+          environment.UNTAPPD_USERNAME && b.recent_checkin_id
+            ? `https://untappd.com/user/${environment.UNTAPPD_USERNAME}/checkin/${b.recent_checkin_id}`
+            : undefined,
       })),
     };
 

--- a/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.html
+++ b/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.html
@@ -10,8 +10,24 @@
   }
   <ul style="padding-left: 0; list-style-type: none">
     @for (beer of data.beers; track beer) {
-      <li style="margin-bottom: 10px">
-        <div style="display: flex; align-items: center">
+      <li style="margin-bottom: 16px">
+        <a
+          [href]="beer.checkinUrl"
+          target="_blank"
+          style="
+            text-decoration: none;
+            color: inherit;
+            display: flex;
+            align-items: center;
+            padding: 8px;
+            border-radius: 8px;
+            transition: background-color 0.2s ease;
+          "
+          [style.cursor]="beer.checkinUrl ? 'pointer' : 'default'"
+          class="beer-item-link"
+          (mouseenter)="$any($event.target).style.backgroundColor = 'rgba(255,255,255,0.05)'"
+          (mouseleave)="$any($event.target).style.backgroundColor = 'transparent'"
+        >
           <img
             [src]="
               beer.beerLabel ||
@@ -19,22 +35,45 @@
             "
             [alt]="beer.beerName"
             style="
-              width: 50px;
-              height: 50px;
-              margin-right: 10px;
+              width: 54px;
+              height: 54px;
+              margin-right: 12px;
               object-fit: cover;
+              border-radius: 4px;
             "
           />
-          <div>
-            <strong style="color: white">{{ beer.beerName }}</strong
-            ><br />
-            <strong style="color: white">{{ beer.breweryName }}</strong
-            ><br />
-            <small>ABV: {{ beer.beerABV }}%</small><br />
-            <small>Rating: {{ beer.rating.toFixed(2) }}/5</small><br />
-            <small>Date: {{ formatDate(beer.checkInDate) }}</small>
+          <div style="flex: 1; min-width: 0">
+            <strong
+              style="
+                color: var(--accent-glow, #ffca28);
+                display: block;
+                overflow: hidden;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              "
+              >{{ beer.beerName }}</strong
+            >
+            <strong
+              style="
+                color: white;
+                font-size: 0.9em;
+                display: block;
+                opacity: 0.9;
+              "
+              >{{ beer.breweryName }}</strong
+            >
+            <div style="font-size: 0.8em; opacity: 0.7; margin-top: 2px">
+              <span>ABV: {{ beer.beerABV }}%</span> •
+              <span>Rating: {{ beer.rating.toFixed(2) }}/5</span>
+            </div>
+            <div style="font-size: 0.75em; opacity: 0.6">
+              {{ formatDate(beer.checkInDate) }}
+            </div>
           </div>
-        </div>
+          @if (beer.checkinUrl) {
+            <mat-icon style="font-size: 18px; width: 18px; height: 18px; opacity: 0.5; margin-left: 8px">open_in_new</mat-icon>
+          }
+        </a>
       </li>
     }
   </ul>

--- a/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.html
+++ b/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.html
@@ -32,7 +32,7 @@
             ><br />
             <small>ABV: {{ beer.beerABV }}%</small><br />
             <small>Rating: {{ beer.rating.toFixed(2) }}/5</small><br />
-            <small>Date: {{ beer.checkInDate }}</small>
+            <small>Date: {{ formatDate(beer.checkInDate) }}</small>
           </div>
         </div>
       </li>

--- a/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.ts
+++ b/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.ts
@@ -3,6 +3,7 @@ import { Component, inject } from "@angular/core";
 import { MAT_DIALOG_DATA, MatDialogModule } from "@angular/material/dialog";
 import { MatButtonModule } from "@angular/material/button";
 import { MatListModule } from "@angular/material/list";
+import { DateUtils } from "../../../core/utils/date-utils";
 
 export interface GenericBeersDialogData {
   title: string;
@@ -25,4 +26,8 @@ export interface GenericBeersDialogData {
 })
 export class BeerStyleDialogComponent {
   data = inject<GenericBeersDialogData>(MAT_DIALOG_DATA);
+
+  formatDate(date: string): string {
+    return DateUtils.formatTimestamp(date);
+  }
 }

--- a/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.ts
+++ b/src/app/shared/components/beer-style-dialog/beer-style-dialog.component.ts
@@ -3,7 +3,8 @@ import { Component, inject } from "@angular/core";
 import { MAT_DIALOG_DATA, MatDialogModule } from "@angular/material/dialog";
 import { MatButtonModule } from "@angular/material/button";
 import { MatListModule } from "@angular/material/list";
-import { DateUtils } from "../../../core/utils/date-utils";
+import { MatIconModule } from "@angular/material/icon";
+import { DateUtils } from "src/app/core/utils/date-utils";
 
 export interface GenericBeersDialogData {
   title: string;
@@ -14,6 +15,7 @@ export interface GenericBeersDialogData {
     beerABV: number;
     rating: number;
     checkInDate: string;
+    checkinUrl?: string;
   }[];
 }
 
@@ -22,7 +24,7 @@ export interface GenericBeersDialogData {
   templateUrl: "./beer-style-dialog.component.html",
   styleUrls: ["./beer-style-dialog.component.css"],
   standalone: true,
-  imports: [MatDialogModule, MatButtonModule, MatListModule],
+  imports: [MatDialogModule, MatButtonModule, MatListModule, MatIconModule],
 })
 export class BeerStyleDialogComponent {
   data = inject<GenericBeersDialogData>(MAT_DIALOG_DATA);

--- a/src/app/shared/components/card/card.component.css
+++ b/src/app/shared/components/card/card.component.css
@@ -155,12 +155,17 @@
 
 .badges-and-social-links {
   display: flex;
-  flex-wrap: wrap;
   justify-content: space-between;
   align-items: center;
   gap: 16px;
   padding: 12px 16px;
   min-height: 48px;
+  overflow-x: auto;
+  scrollbar-width: none; /* Hide scrollbar for Firefox */
+}
+
+.badges-and-social-links::-webkit-scrollbar {
+  display: none; /* Hide scrollbar for Chrome, Safari and Opera */
 }
 
 .global-rating {

--- a/src/app/shared/components/card/card.component.html
+++ b/src/app/shared/components/card/card.component.html
@@ -94,7 +94,7 @@
                   >
                     <img
                       matChipAvatar
-                      [ngSrc]="badge.badge_image.sm"
+                      [src]="badge.badge_image.sm"
                       alt="badge"
                       width="32"
                       height="32"

--- a/src/app/shared/components/pagination/pagination.component.css
+++ b/src/app/shared/components/pagination/pagination.component.css
@@ -8,8 +8,25 @@
   margin: 0 5px;
   background-color: transparent;
   border: none;
-  padding: 5px 10px;
+  padding: 8px 12px;
   color: var(--text-color);
+  border-radius: 8px;
+  transition:
+    background-color 0.2s ease,
+    color 0.2s ease,
+    transform 0.1s ease,
+    opacity 0.2s ease;
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.pagination-controls button:hover:not([disabled]):not(.active) {
+  background-color: rgba(var(--accent-blue-rgb), 0.1);
+  color: var(--accent-blue);
+}
+
+.pagination-controls button:active:not([disabled]) {
+  transform: scale(0.95);
 }
 
 /* Unselected page numbers color - Using theme text color */
@@ -21,10 +38,10 @@
 
 /* Active page number with bold text, accent blue background, and white text */
 .pagination-controls button.page-number.active {
-  font-weight: bold;
+  font-weight: 700;
   background-color: var(--accent-blue);
   color: white !important;
-  border-radius: 4px;
+  box-shadow: 0 4px 8px rgba(var(--accent-blue-rgb), 0.3);
 }
 
 /* Active page number span */
@@ -42,11 +59,6 @@
   border: none;
 }
 
-/* Hover effect for page numbers */
-.pagination-controls button.page-number:hover:not(.active):not(.ellipsis) {
-  background-color: rgba(var(--accent-blue-rgb), 0.1);
-  border-radius: 4px;
-}
 
 /* Disabled button styling */
 .pagination-controls button[disabled] {

--- a/src/assets/data/checkins.json
+++ b/src/assets/data/checkins.json
@@ -21,6 +21,14 @@
             "country_name": "USA",
             "location": { "lat": 32.7157, "lng": -117.1611 },
             "contact": { "url": "http://example.com" }
+          },
+          "badges": {
+            "items": [
+              {
+                "badge_name": "Top Rated Beer",
+                "badge_image": "https://assets.untappd.com/site/assets/images/temp/badge-beer-default.png"
+              }
+            ]
           }
         }
       ]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,10 @@
   "compileOnSave": false,
   "compilerOptions": {
     "baseUrl": "./",
+    "paths": {
+      "@core/*": ["src/app/core/*"],
+      "@shared/*": ["src/app/shared/*"]
+    },
     "outDir": "./dist/out-tsc",
     "forceConsistentCasingInFileNames": true,
     "skipLibCheck": true,


### PR DESCRIPTION
This PR addresses several UI regressions and logic inconsistencies.

Key changes:
1. **Stat Logic Unification**: `HomeComponent` now consumes the centralized `stats$` stream from `BeerStoreService`. This ensures 'Total Checkins', 'Avg Rating', 'Countries', and 'Breweries' values match the Stats page exactly.
2. **Badge Layout**: Removed `flex-wrap` from `.badges-and-social-links` in `CardComponent` and added `overflow-x: auto` (with hidden scrollbars) to force all icons onto the same line as requested.
3. **Badge Data Mapping**: In the Check-ins view, badges now correctly map `created_at` and `badge_description` fields, ensuring the `BadgeDialogComponent` displays complete information when a badge is clicked.
4. **Test Stability**: Updated `stats.component.spec.ts` and `home.component.spec.ts` to fix failures caused by stale mock definitions.

---
*PR created automatically by Jules for task [395839480575188345](https://jules.google.com/task/395839480575188345) started by @cfrome77*