### PR TITLE
Move 'Powered by Untappd' logo to About section

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -20,24 +20,6 @@
   overflow: hidden;
 }
 
-.untappd-logo-container {
-  position: fixed;
-  bottom: 15px;
-  left: 15px;
-  z-index: 100;
-}
-
-.untappd-logo {
-  max-height: 40px;
-  width: auto;
-  opacity: 0.8;
-  transition: opacity 0.3s;
-}
-
-.untappd-logo:hover {
-  opacity: 1;
-}
-
 #fab-dismiss {
   position: fixed;
   top: 0;
@@ -178,13 +160,5 @@ mat-toolbar {
   /* Add padding to the main container to account for bottom nav */
   .main-container {
     padding-bottom: 60px;
-  }
-
-  .untappd-logo-container {
-    bottom: 75px;
-  }
-
-  .untappd-logo {
-    max-height: 30px;
   }
 }

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -187,15 +187,6 @@
       <router-outlet #outlet="outlet"></router-outlet>
     </div>
   </mat-drawer-container>
-  <div class="untappd-logo-container">
-    <img
-      src="assets/images/poweredbyuntappd.png"
-      alt="Powered by Untappd"
-      class="untappd-logo"
-      width="200"
-      height="75"
-    />
-  </div>
 
   @defer (on idle) {
     <app-info-fab></app-info-fab>

--- a/src/app/components/about/about.component.html
+++ b/src/app/components/about/about.component.html
@@ -55,6 +55,8 @@
       chris&#64;chrisfrome.com
     </a>
   </section>
+
+  <app-powered-by></app-powered-by>
 </mat-dialog-content>
 
 <mat-dialog-actions align="end" class="about-actions">

--- a/src/app/components/about/about.component.ts
+++ b/src/app/components/about/about.component.ts
@@ -3,13 +3,19 @@ import { Component } from "@angular/core";
 
 import { MatDialogModule } from "@angular/material/dialog";
 import { MatButtonModule } from "@angular/material/button";
+import { PoweredByComponent } from "../../shared/components/powered-by/powered-by.component";
 
 @Component({
   selector: "app-about",
   templateUrl: "./about.component.html",
   styleUrls: ["./about.component.css"],
   standalone: true,
-  imports: [MatDialogModule, MatButtonModule, MatIconModule],
+  imports: [
+    MatDialogModule,
+    MatButtonModule,
+    MatIconModule,
+    PoweredByComponent,
+  ],
 })
 export class AboutComponent {
   constructor() {}

--- a/src/app/components/badges/badges.component.css
+++ b/src/app/components/badges/badges.component.css
@@ -24,10 +24,3 @@ p {
   text-decoration: none;
 }
 
-/* Powered by Untappd image */
-.powered-by {
-  display: block;
-  margin: 20px auto 0;
-  max-width: 150px;
-  height: auto;
-}

--- a/src/app/shared/components/powered-by/powered-by.component.css
+++ b/src/app/shared/components/powered-by/powered-by.component.css
@@ -1,4 +1,6 @@
 .powered-by {
   display: block;
-  margin: 15px auto 15px;
+  margin: 15px auto;
+  max-height: 40px;
+  width: auto;
 }


### PR DESCRIPTION
I have moved the 'Powered by Untappd' logo from its floating position in the main application layout to the bottom of the 'About' dialog. This was achieved by:
1. Removing the floating logo container and associated styles from `AppComponent`.
2. Importing and adding the shared `PoweredByComponent` to the `AboutComponent` template.
3. Updating `PoweredByComponent` styles to ensure it is centered and properly sized within the dialog.
4. Removing unused logo styles from `BadgesComponent`.

I verified the changes by running the application locally and using a Playwright script to capture a screenshot of the logo in its new location at the bottom of the About dialog. All unit tests passed.

---
*PR created automatically by Jules for task [15374001680909839799](https://jules.google.com/task/15374001680909839799) started by @cfrome77*